### PR TITLE
バグの修正　3箇所＋α

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -26,7 +26,7 @@ DIRECTIONS = [
 def output(board)
   puts "  #{ROW.join(' ')}"
   board.each.with_index do |row, i|
-    print COL[i].to_s
+    print COL[i]
     row.each do |cell|
       case cell
       when WHITE_STONE then print ' ○'
@@ -53,7 +53,7 @@ def put_stone!(board, cellstr, stone_color, execute = true) # rubocop:disable St
 
   # コピーした盤面にて石の配置を試みて、成功すれば反映する
   copied_board = Marshal.load(Marshal.dump(board))
-  copied_board[pos.row][pos.col] = stone_color
+  copied_board[pos.col][pos.row] = stone_color
 
   turn_succeed = false
   DIRECTIONS.each do |direction|
@@ -69,7 +69,7 @@ end
 # target_posはひっくり返す対象セル
 def turn!(board, target_pos, attack_stone_color, direction)
   return false if target_pos.out_of_board?
-  return false if target_pos.stone_color(board) == attack_stone_color
+  return false if target_pos.stone_color(board) == attack_stone_color || target_pos.stone_color(board).zero?
 
   next_pos = target_pos.next_position(direction)
   if (next_pos.stone_color(board) == attack_stone_color) || turn!(board, next_pos, attack_stone_color, direction)
@@ -93,6 +93,7 @@ def placeable?(board, attack_stone_color)
       return true if put_stone!(board, position.to_cellstr, attack_stone_color, false)
     end
   end
+  false
 end
 
 def count_stone(board, stone_color)


### PR DESCRIPTION
３つのバグが存在した。

1. put_stone!メソッドにおいて、配列のインデックスとしてのcolumn,rowが逆になっていたことにより、 入力した座標と異なる位置に石が配置されていた。

2. turn!メソッドにおいて、石間のマスが空きマスであっても裏返し判定を中断していないことにより、 自石を置いても相手の石を裏返せない場所にも置けていた。

3. placeable?メソッドにおいて、本来石が置けないときはfalseを返すべきだが、board変数が返ってきており（つまりtrue）、 終了すべきときに正しく終了判定されていなかった。

+α　rubocopによる警告   冗長な文字列変換 to_sメソッド
Lint/RedundantStringCoercion: Redundant use of Object#to_s in print.